### PR TITLE
Add Typescript types

### DIFF
--- a/lib/cronitor.d.ts
+++ b/lib/cronitor.d.ts
@@ -1,0 +1,117 @@
+import { ScheduledTask } from 'node-cron';
+
+type MonitorState = 'run' | 'complete' | 'fail' | 'ok';
+
+type MonitorType = 'job' | 'heartbeat' | 'check';
+
+type CronitorConfig = {
+    config?: string; // Path to config file
+    apiVersion?: string;
+    timeout?: number;
+    environment?: string;
+}
+
+/**
+ * https://cronitor.io/docs/telemetry-api#parameters
+ */
+type TelemetryEvent = {
+    state: MonitorState; // Indicate a state change for a monitor
+    env?: string; // The environment the telemetry event is being sent from
+    message?: string; // A URL-encoded message of up to 2000 characters
+    metrics?: {
+        duration?: number;
+        count?: number;
+        error_count?: number;
+    };
+    host?: string; // The hostname of the server sending the telemetry event
+    series?: string; // A unique user-supplied ID to collate related pings
+    status_code?: number; // Exit code returned from a background job
+}
+
+/**
+ * https://cronitor.io/docs/monitor-api#attributes
+ */
+type MonitorAttributes = {
+    type: MonitorType; // Monitor type (required)
+    key: string; // Monitor's unique identifier (required)
+    schedule?: string; // Schedule for monitoring
+    assertions?: string[]; // Array containing strings
+    group?: string; // Group name
+    metadata?: Record<string, any>; // JSON serializable key/value pairs
+    name?: string; // Display name of the monitor
+    note?: string; // Additional context/troubleshooting information
+    notify?: string[] | { alerts: string[]; events: Record<string, boolean> }; // Notification settings
+    paused?: boolean; // Monitoring/alerting status
+    platform?: string; // Platform information
+    grace_seconds?: number; // Number of seconds for grace period
+    tags?: string[]; // Array of tags
+    timezone?: string; // Timezone
+    schedule_tolerance?: number; // Schedule tolerance
+    failure_tolerance?: number; // Failure tolerance
+    created?: string; // Timestamp when the monitor was created
+    disabled?: boolean; // Current disabled status
+    initialized?: boolean; // Whether the monitor has received a telemetry event
+    passing?: boolean; // Whether the monitor is currently passing or failing
+    running?: boolean; // Whether a job is running (only applicable for type: job)
+    defaultName?: string; // Default name for provisioning
+    defaultNote?: string; // Default note for provisioning
+    realert_interval?: number | string; // Interval for follow-up alerts
+    request?: {
+        url: string;
+        method?: string;
+        body?: string;
+        headers?: Record<string, string>;
+        cookies?: Record<string, string>;
+        timeout_seconds?: number;
+        follow_redirects?: boolean;
+        verify_ssl?: boolean;
+    }; // required by type: check
+};
+
+declare interface Monitor {
+    new(key: string): Monitor;
+    get State(): MonitorState;
+    put(data: MonitorAttributes | MonitorAttributes[], rollback?: boolean): Promise<Monitor | Monitor[]>;
+    data(): Promise<any>;
+    pause(hours: number): Promise<boolean>;
+    unpause(): Promise<boolean>;
+    ok(params?: TelemetryEvent): Promise<boolean>;
+    delete(): Promise<boolean>;
+    ping(params?: TelemetryEvent): Promise<boolean>;
+}
+
+declare interface Event {
+    new(key: string, options?: { intervalSeconds?: number }): Event;
+    tick(count?: number): void;
+    error(count?: number): void;
+    stop(): Promise<void>;
+    fail(message?: string | null): Promise<void>;
+}
+
+declare class Cronitor {
+    constructor(apiKey: string, config?: CronitorConfig);
+    generateConfig(): Promise<void>;
+    applyConfig(rollback?: boolean): Promise<void>;
+    validateConfig(): Promise<void>;
+    readConfig(path: string | null, output?: boolean): void;
+    wrap(key: string, callback: () => Promise<any>): () => Promise<any>;
+    wraps(lib: any): void;
+    newSeries(): string;
+    schedule(key: string, schedule: string, cb: Function, options?: any): ScheduledTask | void;
+
+    Monitor: Monitor;
+    Event: Event;
+
+    static State: {
+        RUN: 'run';
+        COMPLETE: 'complete';
+        FAIL: 'fail';
+        OK: 'ok';
+    };
+}
+
+declare function cronitor(apiKey: string, config?: CronitorConfig): Cronitor;
+
+export = cronitor;
+
+export as namespace cronitor;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.4",
   "description": "A small library for reliably monitoring cron jobs, control-loops, or other important system events with Cronitor.",
   "main": "lib/cronitor.js",
+  "types": "lib/cronitor.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/cronitorio/cronitor-js.git"


### PR DESCRIPTION
TypeScript support for @cronitor - js@v2.3.4.
Types are derived directly from the [latest release(2.3.4)](https://github.com/cronitorio/cronitor-js/releases/tag/2.3.4) and the [API docs](https://cronitor.io/docs).

### Notes on module exports
To let TypeScript users consume the module while also providing a structure similar to the original JavaScript exports:
```typescript
export = cronitor;

export as namespace cronitor;
```
The first line, `export = cronitor` exports the Cronitor instantiation function as the default export of the module. This means we can import it using both CommonJS and ESM:
```typescript
import cronitor from 'cronitor'; // with ESM
const cronitor = require('cronitor'); // with CommonJS
```

The second line, `export as namespace cronitor`, declares the function call as a namespace, allowing us to access its properties and methods, e.g.:
```typescript 
import cron from 'cronitor';

const cronitor = cron('api_key');
cronitor.readConfig()
new cronitor.Monitor()
new cronitor.Event()
```

### Tested
- Compiling (with `tsc`) example implementations from README using tsconfig `compilerOptions.target` ES2015 -> ESNext ✅ 
- `npm test` ✅ 

### Suggestions for further improvements
- Add TypeScript/ESM implementation examples to README.
- Export types to make them available to package users (might require some deviance from original JS export structure)