### PR TITLE
Rename  method to  in Monitor class and add tests

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -66,7 +66,7 @@ class Monitor {
         this._api = this.constructor._api;
     }
 
-    async data() {
+    async loadData() {
         return this._api.axios
             .get(this._api.monitorUrl(this.key))
             .then((res) => {

--- a/test/test.js
+++ b/test/test.js
@@ -201,6 +201,31 @@ describe('Monitor', () => {
         expect(stub).to.be.calledWith('https://eu.cronitor.link/ping/apiKey123/a-key');
         done();
     });
+
+    it('should load monitor data', async function() {
+        const monitor = new cronitor.Monitor('a-key');
+        const mockResponse = { data: { name: 'Test Monitor', type: 'job' } };
+        const stub = sinon.stub(monitor._api.axios, 'get').resolves(mockResponse);
+        
+        const result = await monitor.loadData();
+        
+        expect(stub).to.be.calledWith(monitor._api.monitorUrl(monitor.key));
+        expect(result).to.deep.equal(mockResponse.data);
+        expect(monitor.data).to.deep.equal(mockResponse.data);
+    });
+
+    it('should return error response when loadData fails', async function() {
+        const monitor = new cronitor.Monitor('a-key');
+        const errorResponse = { status: 404, data: { error: 'Not Found' } };
+        const stub = sinon.stub(monitor._api.axios, 'get')
+            .rejects({ response: errorResponse });
+        
+        const result = await monitor.loadData();
+        
+        expect(stub).to.be.calledWith(monitor._api.monitorUrl(monitor.key));
+        expect(result).to.deep.equal(errorResponse);
+        expect(monitor.data).to.be.null;
+    });
 });
 
 describe('Event', () => {


### PR DESCRIPTION
When I use the cronitor-js SDK to get monitor data, the data method always throws an error saying "data is not a function." So I checked the code and found that the monitor has a property also called data, which overrides the method.

```
    const cronitorClient = getCronitorClient();
    const monitorInstance = new cronitorClient.Monitor(alert.id);
    console.log('monitorInstance.data:', monitorInstance.data);

    const response = await monitorInstance.data() as IMonitor;
```

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/737ee4f0-32a4-4805-ad51-086b5e927dd6" />

